### PR TITLE
[CTCORE-10278] Readme correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 The official Coveo C# SDK allows your software to communicate with the Coveo Cloud Platform public APIs and the Push API.
 
-The package is .NET Standard 2.0 compatible and therefore works with .NET Core and .NET Framework
-
 The code of the SDK is not open-source. This repository is meant to handle feedback, bug reporting, etc.
 
 ## Installation


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CTCORE-10278

Removed the reference to the version. We can look at Nuget for the supported versions. This will facilate the maintenance when we will migrate to .NET8 and other framework,

I didn't find other thing to update.